### PR TITLE
Minor copyedit

### DIFF
--- a/Specification-Draft.MD
+++ b/Specification-Draft.MD
@@ -5,7 +5,7 @@ FDC3 API standards support the following goals:
 - Standardize interfaces between Desktop Agents
 # 1. Components
 ## 1.1 Desktop Agent
-A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for App identity and discovery.   Typically, an Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are higher.  
+A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.  
 
 Examples of Desktop Agents include:
 
@@ -26,17 +26,17 @@ Examples of End Points include:
 - Headless “services” running on the desktop 
 # 2. Functional Use Cases
 ## 2.1 Open an Application by Name
-Linking from one application to another is a critical basic workflow that the web revolutionized via the hyperlink.  Supporting semantic addressing of applications across different technologies and platform domains greatly reduces friction in linking different apps into a single workflow.
+Linking from one application to another is a critical basic workflow that the web revolutionized via the hyperlink.  Supporting semantic addressing of applications across different technologies and platform domains greatly reduces friction in linking different applications into a single workflow.
 ## 2.2 Link to functionality by Intent
-Often, we want to link from one App to another to chain together workflow.  Enabling this without Apps needing prior knowledge of each other is a key goal of FDC3.   Intent workflows fall into the following types:
-- Chain:  in this case the workflow is completely handed off from one App to another (similar to linking).   Currently, this is the primary focus in FDC3
-- Client-Service: In these cases,  a Client invokes a Service via the Intent, the service performs some function, then passes the workflow back to the Client.  Usually, there is a data payload associated with this workflow and a request/response pattern.
+Often, we want to link from one app to another to chain together workflow.  Enabling this without apps needing prior knowledge of each other is a key goal of FDC3.   Intent workflows fall into the following types:
+- Chain:  in this case the workflow is completely handed off from one app to another (similar to linking).   Currently, this is the primary focus in FDC3
+- Client-Service: In these cases,  a Client invokes a Service via the Intent, the Service performs some function, then passes the workflow back to the Client.  Usually, there is a data payload associated with this workflow and a request/response pattern.
 ## 2.3 Register an Intent
-Applications need to let the system know what intents they can support.  Typically, this is done via registration in App Directory.  However, intents can also be registered at the application level as well to support ad-hoc registration which is especially helpful at development time.  A Desktop Agent may decide to treat dynamically registered intents differently than ones registered by directory - depending on the security profile of the environment.
+Applications need to let the system know the Intents they can support.  Typically, this is done via registration with the App Directory.  However, Intents can also be registered at the application level as well to support ad-hoc registration which is especially helpful at development time.  A Desktop Agent may decide to treat dynamically registered intents differently than ones registered by App Directory - depending on the security profile of the environment.
 ## 2.4 Send/broadcast context  
-On the financial desktop, Applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.  
+On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.  
 # 3. Resolvers
-Intents functionality is dependent on resolver functionality to map the intent to a specific App.  This will often require end-user input.  Resolution can either be performed by the Desktop Agent (raising UI to pick the desired App for the intent) or by the App launching the intent - in which case the calling App will handle the resolution itself (using the resolve API below) and then invoke an explicit Intent object.
+Intents functionality is dependent on resolver functionality to map the intent to a specific App.  This will often require end-user input.  Resolution can either be performed by the Desktop Agent (raising UI to pick the desired App for the intent) or by the app launching the intent - in which case the calling App will handle the resolution itself (using the resolve API below) and then invoke an explicit Intent object.
 # 4. APIs
 Note - these APIs are specified in pseudo-code and for convenience written in a synchronous style.  Many or all implementations would be expected to be async using a Promise or callback pattern.  
 ## 4.1 Agent
@@ -44,13 +44,13 @@ Note - these APIs are specified in pseudo-code and for convenience written in a 
 Referred to via **fdc3** object
 
 ## 4.2 register
-Dynamically registers an intent with the agent.  Returns confirmation of the registration.
+Dynamically registers an Intent with the agent.  Returns confirmation of the registration.
 ```script
 fdc3.register(intent: String)
 ```
 ## 4.3 open
-Launches/links to an App by name.
-Returns a Promise - resolving if the App is opened, rejecting if an error occurs.
+Launches/links to an app by name.
+Returns a Promise - resolving if the app is opened, rejecting if an error occurs.
 ```script
 fdc3.open(name: String, context: Object) > Promise
 ```
@@ -61,11 +61,11 @@ fdc3.open(name: String, context: Object) > Promise
 - App timeout
 - Resolver crashed / unavailable
 
-*Note:* open no longer takes an ‘intent’ argument.  This is now moved to the more specific intent API below.
+*Note:* open no longer takes an ‘intent’ argument.  This is now moved to the more specific Intent API below.
 ## 4.4 resolve
 Resolves a intent & context pair to a list of App names/metadata. 
 
-Resolve is effectively granting programmatic access to the Desktop Agent's resolver.  Returns a promise, resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific. The returned array of objects should support a Name property that is the name of the App
+Resolve is effectively granting programmatic access to the Desktop Agent's resolver.  Returns a promise, resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific. The returned array of objects should support a Name property that is the name of the app.
 ```script
 fdc3.resolve(intent: String, context: Object) > Promise
 ```
@@ -76,7 +76,7 @@ fdc3.resolve(intent: String, context: Object) > Promise
 
 *Note:* This method could also be used by federated Desktop Agents to query for resolution from other Desktop Agents (and then aggregate results).
 ## 4.5 broadcast
-Publishes context to other Apps on the desktop.  
+Publishes context to other apps on the desktop.  
 ```script
 fdc3.broadcast(context: Object) 
 ```
@@ -99,10 +99,10 @@ Getter/Setter for context data on the intent.
 Intent.context = {...};
 ```
 ### 4.6.3 target
-Getter/Setter.  Name of App to target for the Intent. Use if creating an explicit intent that bypasses resolver and goes directly to an App.
+Getter/Setter.  Name of app to target for the Intent. Use if creating an explicit intent that bypasses resolver and goes directly to an app.
 
 ### 4.6.4 send
-Dispatches the intent with the Agent.  Accepts contextData and target (if an explicit Intent) as optional args.  Returns a Promise - resolving if the intent successfully results in launching an App, rejecting if an error state occurs.
+Dispatches the intent with the Desktop Agent.  Accepts context data and target (if an explicit Intent) as optional args.  Returns a Promise - resolving if the intent successfully results in launching an App, rejecting if an error state occurs.
 ```script	
 	Intent.send(context: Object, target: String) > Promise
 ```
@@ -114,9 +114,9 @@ Dispatches the intent with the Agent.  Accepts contextData and target (if an exp
 - Timeout from Resolver
 
 ## 4.7 IntentListener Object
-Listens to incoming intents from the Agent.
+Listens to incoming Intents from the Agent.
 ### 4.7.1 Constructor
-Accepts name of intent to handle and handler function
+Accepts name of Intent to handle and handler function
 ```script
 var listen =  new fdc3.IntentListener(“ViewChart”, context => {...});
 ```
@@ -130,7 +130,7 @@ var listen =  new fdc3.ContextListener( handler: Function);
 ```
 # 5. Appendix
 ## 5.1 Proposed Selector Syntax
-A selector syntax for App discovery and connectivity.  For example:
+A selector syntax for app discovery and connectivity.  For example:
 ```script
 fdc3.publish("group .topic",{ctx}) 
 ```


### PR DESCRIPTION
Capitalising FDC3-specific terms, e.g. 'Desktop Agent', that are proper nouns - and removing capitalisation of more general terms, e.g. application / app, that do not have a FDC3 specific meaning