### PR TITLE
Api enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/FDC3/API.git",
   "license": "Apache-2.0",
   "scripts": {
+    "build": "tsc",
     "test": "mocha -r ts-node/register ./test/*.spec.ts",
     "doc": "typedoc --theme markdown --out docs src "
   },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,15 @@
   "repository": "https://github.com/FDC3/API.git",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "tsc",
+    "test": "mocha -r ts-node/register ./test/*.spec.ts",
     "doc": "typedoc --theme markdown --out docs src "
   },
   "devDependencies": {
+    "@types/chai": "^4.1.4",
+    "@types/mocha": "^5.2.3",
+    "chai": "^4.1.2",
+    "mocha": "^5.2.0",
+    "ts-node": "^6.1.2",
     "typedoc": "^0.11.1",
     "typedoc-plugin-markdown": "^1.1.12",
     "typescript": "^2.8.4"

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,7 +19,15 @@ enum ResolveError {
  * the result of calling desktopAgent.resolve() is `Promise<ResolveResults>`
  * the ResolveResult contains the list of apps which support the intent
  */
-export interface ResolveResults {
+export interface RaiseIntentResults {
+    data: any;
+}
+
+/**
+ * the result of calling desktopAgent.resolve() is `Promise<ResolveResults>`
+ * the ResolveResult contains the list of apps which support the intent
+ */
+export interface ResolveIntentResults {
     targets: AppMetadata[];
 }
 
@@ -59,6 +67,7 @@ export interface Intent {
 
 /**
  * App metadata is Desktop Agent specific - but should support a name property.
+ * This could be an application as defined by the FDC3 working group.
  */
 export interface AppMetadata {
   name: AppIdentifier;
@@ -82,18 +91,11 @@ export interface Listener {
  */
 export interface DesktopAgent {
   /**
-   * Launches/links to an app by name.
+   * Launches/links to an app by name, this is typically called after a call to resolveIntent
    * 
    * If opening errors, it returns an `Error` with a string from the `OpenError` enumeration.
    */
-  open(app: AppMetadata, context: Context): Promise<void>;
-
-  /**
-   * sends an intent, containing a context and optional target
-   * 
-   * If firing errors, it returns an `Error` with a string from the `ResolveError` or `OpenError` enumerations.
-   */
-  sendIntent(intent: Intent): Promise<void>;
+  open(app: AppMetadata, intent: Intent): Promise<void>;
 
   /**
    * Resolves a intent & context pair to a list of App names/metadata.
@@ -102,7 +104,7 @@ export interface DesktopAgent {
    * Returns a promise that resolves to an Array. The resolved dataset & metadata is Desktop Agent-specific.
    * If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
    */
-  resolve(intent: Intent): Promise<ResolveResults>;
+  resolveIntent(intent: Intent): Promise<ResolveIntentResults>;
 
   /**
    * Resolves a context to a list of intents supported by the subsystem.
@@ -112,6 +114,13 @@ export interface DesktopAgent {
    * If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
    */
   resolveContext(context: Context): Promise<ResolveContextResults>;
+
+  /**
+   * sends an intent, containing a context and optional target
+   * 
+   * If firing errors, it returns an `Error` with a string from the `ResolveError` or `OpenError` enumerations.
+   */
+  raiseIntent(intent: Intent): Promise<RaiseIntentResults>;
 
   /**
    * Publishes context to other apps on the desktop.
@@ -126,10 +135,10 @@ export interface DesktopAgent {
   /**
    * Listens to incoming Intents from the Agent.
    */
-  intentListener(intent: string, handler: (context: Context) => void): Listener;
+  newIntentListener(intent: string, handler: (context: Context) => void): Listener;
 
   /**
    * Listens to incoming context broadcast from the Desktop Agent.
    */
-  contextListener(handler: (context: Context) => void): Listener;
+  newContextListener(handler: (context: Context) => void): Listener;
 }

--- a/test/desktopAgent.spec.ts
+++ b/test/desktopAgent.spec.ts
@@ -1,6 +1,7 @@
 import { desktopAgent } from './mockDesktopAgent';
 import { expect } from 'chai';
 import 'mocha';
+import { ResolveResults, ResolveContextResults } from '../src/interface';
 
 const contact = { id: 'me@asdf.com' };
 const company = { name: 'the company', symbol: 'asdf.n' };
@@ -10,23 +11,23 @@ describe('DesktopAgent', () => {
 
     it('should have two resolvers for startChat intent', async () => {
         let theIntent = desktopAgent.newIntent('startChat', contact);
-        let resolvers = await desktopAgent.resolve(theIntent);
+        let result:ResolveResults = await desktopAgent.resolve(theIntent);
 
-        expect(2).to.be.equal(resolvers.length);
-        return await desktopAgent.open(resolvers[0].metaData, contact);
+        expect(2).to.be.equal(result.targets.length);
+        return await desktopAgent.open(result.targets[0], contact);
     });
 
     it('should have two resolutions for company context', async function() {
-        const ctxResos = await desktopAgent.resolveContext(company);
+        const result:ResolveContextResults = await desktopAgent.resolveContext(company);
 
-        expect(1).to.be.equal(ctxResos.length);
-        expect('viewChart').to.be.equal(ctxResos[0].intentName);
-        expect(2).to.be.equal(ctxResos[0].targets.length);
+        expect(1).to.be.equal(result.intents.length);
+        expect('viewChart').to.be.equal(result.intents[0].intentName);
+        expect(2).to.be.equal(result.intents[0].targets.length);
 
         // this is redundant, usually you'd either call fire or open but for testing purposes ...
-        let theIntent = desktopAgent.newIntent(ctxResos[0].intentName, company);
-        desktopAgent.fire(theIntent);
-        return desktopAgent.open(ctxResos[0].targets[0], company);
+        let theIntent = desktopAgent.newIntent(result.intents[0].intentName.valueOf(), company);
+        desktopAgent.sendIntent(theIntent);
+        return desktopAgent.open(result.intents[0].targets[0], company);
     });
 
   });

--- a/test/desktopAgent.spec.ts
+++ b/test/desktopAgent.spec.ts
@@ -1,7 +1,7 @@
 import { desktopAgent } from './mockDesktopAgent';
 import { expect } from 'chai';
 import 'mocha';
-import { ResolveResults, ResolveContextResults } from '../src/interface';
+import { ResolveIntentResults, ResolveContextResults, AppMetadata } from '../src/interface';
 
 const contact = { id: 'me@asdf.com' };
 const company = { name: 'the company', symbol: 'asdf.n' };
@@ -11,23 +11,26 @@ describe('DesktopAgent', () => {
 
     it('should have two resolvers for startChat intent', async () => {
         let theIntent = desktopAgent.newIntent('startChat', contact);
-        let result:ResolveResults = await desktopAgent.resolve(theIntent);
+        let result:ResolveIntentResults = await desktopAgent.resolveIntent(theIntent);
 
         expect(2).to.be.equal(result.targets.length);
-        return await desktopAgent.open(result.targets[0], contact);
+        return await desktopAgent.open(result.targets[0], theIntent);
     });
 
     it('should have two resolutions for company context', async function() {
         const result:ResolveContextResults = await desktopAgent.resolveContext(company);
 
         expect(1).to.be.equal(result.intents.length);
-        expect('viewChart').to.be.equal(result.intents[0].intentName);
-        expect(2).to.be.equal(result.intents[0].targets.length);
+
+        const firstIntent = result.intents[0];
+        expect('viewChart').to.be.equal(firstIntent.intentName);
+        expect(2).to.be.equal(firstIntent.targets.length);
 
         // this is redundant, usually you'd either call fire or open but for testing purposes ...
-        let theIntent = desktopAgent.newIntent(result.intents[0].intentName.valueOf(), company);
-        desktopAgent.sendIntent(theIntent);
-        return desktopAgent.open(result.intents[0].targets[0], company);
+        const target:AppMetadata = firstIntent.targets[0];
+        const newIntent = desktopAgent.newIntent(firstIntent.intentName.valueOf(), company);
+        desktopAgent.raiseIntent(newIntent);
+        return desktopAgent.open(target, newIntent);
     });
 
   });

--- a/test/desktopAgent.spec.ts
+++ b/test/desktopAgent.spec.ts
@@ -1,0 +1,33 @@
+import { desktopAgent } from './mockDesktopAgent';
+import { expect } from 'chai';
+import 'mocha';
+
+const contact = { id: 'me@asdf.com' };
+const company = { name: 'the company', symbol: 'asdf.n' };
+
+describe('DesktopAgent', () => {
+  describe('resolve', () => {
+
+    it('should have two resolvers for startChat intent', async () => {
+        let theIntent = desktopAgent.newIntent('startChat', contact);
+        let resolvers = await desktopAgent.resolve(theIntent);
+
+        expect(2).to.be.equal(resolvers.length);
+        return await desktopAgent.open(resolvers[0].metaData, contact);
+    });
+
+    it('should have two resolutions for company context', async function() {
+        const ctxResos = await desktopAgent.resolveContext(company);
+
+        expect(1).to.be.equal(ctxResos.length);
+        expect('viewChart').to.be.equal(ctxResos[0].intentName);
+        expect(2).to.be.equal(ctxResos[0].targets.length);
+
+        // this is redundant, usually you'd either call fire or open but for testing purposes ...
+        let theIntent = desktopAgent.newIntent(ctxResos[0].intentName, company);
+        desktopAgent.fire(theIntent);
+        return desktopAgent.open(ctxResos[0].targets[0], company);
+    });
+
+  });
+});

--- a/test/mockDesktopAgent.ts
+++ b/test/mockDesktopAgent.ts
@@ -1,0 +1,69 @@
+// MOCK desktop agent
+
+import {AppMetadata, Context, ResolveResult, ResolveContextResult, DesktopAgent, Intent, Listener} from "../src/interface"
+
+const appMetaDataList:AppMetadata[] = [
+    { id: 'myChatApp', name: 'myChatApp'}
+    ,{ id: 'myChartApp', name: 'myChartApp'}
+    ,{ id: 'myAppThatSupportsAllContexts', name: 'myAppThatSupportsAllContexts'}
+];
+
+const intents2ResolveResultsMap = {
+    'viewChart' : [ 
+        appMetaDataList[1]
+        ,appMetaDataList[2]
+    ],
+    'startChat' : [
+        appMetaDataList[0]
+        ,appMetaDataList[2]
+    ],
+    'viewContact' : [
+        appMetaDataList[0]
+        ,appMetaDataList[2]
+    ]
+};
+
+
+export const desktopAgent:DesktopAgent = {
+
+    open: async function(app: AppMetadata, context: Context): Promise<void> {
+        return;        
+    },
+
+    newIntent: function(name: string, context: Context, target?: AppMetadata): Intent {
+        return {
+            name: name,
+            context: context,
+            target: target
+        };
+    },
+    
+    resolve: async function(intent: Intent): Promise<Array<ResolveResult>> {
+        return intents2ResolveResultsMap[intent.name];
+    },
+
+    resolveContext: async function(context: Context): Promise<Array<ResolveContextResult>> {
+        if ( typeof context.userid !== 'undefined' ) {
+            const resolver1 = { intentName: 'startChat', targets: intents2ResolveResultsMap['startChat'] };
+            const resolver2 = { intentName: 'viewContact', targets: intents2ResolveResultsMap['viewContact'] };
+            return [resolver1, resolver2];
+        } else if ( typeof context.symbol !== 'undefined' ) {
+            return [{ intentName: 'viewChart', targets: intents2ResolveResultsMap['viewChart'] }];
+        }
+    },
+
+    fire: async function(intent: Intent) {
+        return;
+    },
+
+    broadcast: function() {
+    },
+
+    intentListener: function(intent: string, handler: (context: Context) => void):Listener {
+        return { unsubscribe: () => {} };
+    },
+    
+    contextListener: function(handler: (context: Context) => void):Listener {
+        return { unsubscribe: () => {} };
+    }
+}

--- a/test/mockDesktopAgent.ts
+++ b/test/mockDesktopAgent.ts
@@ -1,11 +1,11 @@
 // MOCK desktop agent
 
-import {AppMetadata, Context, ResolveResult, ResolveContextResult, DesktopAgent, Intent, Listener} from "../src/interface"
+import {AppMetadata, Context, ResolveResults, ResolveContextResults, ResolveContextResult, DesktopAgent, Intent, Listener} from "../src/interface"
 
 const appMetaDataList:AppMetadata[] = [
-    { id: 'myChatApp', name: 'myChatApp'}
-    ,{ id: 'myChartApp', name: 'myChartApp'}
-    ,{ id: 'myAppThatSupportsAllContexts', name: 'myAppThatSupportsAllContexts'}
+    { name: 'myChatApp'}
+    ,{ name: 'myChartApp'}
+    ,{ name: 'myAppThatSupportsAllContexts'}
 ];
 
 const intents2ResolveResultsMap = {
@@ -38,21 +38,22 @@ export const desktopAgent:DesktopAgent = {
         };
     },
     
-    resolve: async function(intent: Intent): Promise<Array<ResolveResult>> {
-        return intents2ResolveResultsMap[intent.name];
+    resolve: async function(intent: Intent): Promise<ResolveResults> {
+        const rr:ResolveResults = { targets: intents2ResolveResultsMap[intent.name.valueOf()] }
+        return rr;
     },
 
-    resolveContext: async function(context: Context): Promise<Array<ResolveContextResult>> {
+    resolveContext: async function(context: Context): Promise<ResolveContextResults> {
         if ( typeof context.userid !== 'undefined' ) {
             const resolver1 = { intentName: 'startChat', targets: intents2ResolveResultsMap['startChat'] };
             const resolver2 = { intentName: 'viewContact', targets: intents2ResolveResultsMap['viewContact'] };
-            return [resolver1, resolver2];
+            return { intents: [resolver1, resolver2] };
         } else if ( typeof context.symbol !== 'undefined' ) {
-            return [{ intentName: 'viewChart', targets: intents2ResolveResultsMap['viewChart'] }];
+            return { intents: [{ intentName: 'viewChart', targets: intents2ResolveResultsMap['viewChart'] }] };
         }
     },
 
-    fire: async function(intent: Intent) {
+    sendIntent: async function(intent: Intent) {
         return;
     },
 

--- a/test/mockDesktopAgent.ts
+++ b/test/mockDesktopAgent.ts
@@ -1,6 +1,6 @@
 // MOCK desktop agent
 
-import {AppMetadata, Context, ResolveResults, ResolveContextResults, ResolveContextResult, DesktopAgent, Intent, Listener} from "../src/interface"
+import {AppMetadata, Context, RaiseIntentResults, ResolveIntentResults, ResolveContextResults, ResolveContextResult, DesktopAgent, Intent, Listener} from "../src/interface"
 
 const appMetaDataList:AppMetadata[] = [
     { name: 'myChatApp'}
@@ -26,7 +26,7 @@ const intents2ResolveResultsMap = {
 
 export const desktopAgent:DesktopAgent = {
 
-    open: async function(app: AppMetadata, context: Context): Promise<void> {
+    open: async function(app: AppMetadata, intent: Intent): Promise<void> {
         return;        
     },
 
@@ -38,8 +38,8 @@ export const desktopAgent:DesktopAgent = {
         };
     },
     
-    resolve: async function(intent: Intent): Promise<ResolveResults> {
-        const rr:ResolveResults = { targets: intents2ResolveResultsMap[intent.name.valueOf()] }
+    resolveIntent: async function(intent: Intent): Promise<ResolveIntentResults> {
+        const rr:ResolveIntentResults = { targets: intents2ResolveResultsMap[intent.name.valueOf()] }
         return rr;
     },
 
@@ -53,18 +53,18 @@ export const desktopAgent:DesktopAgent = {
         }
     },
 
-    sendIntent: async function(intent: Intent) {
+    raiseIntent: async function(intent: Intent): Promise<RaiseIntentResults> {
         return;
     },
 
     broadcast: function() {
     },
 
-    intentListener: function(intent: string, handler: (context: Context) => void):Listener {
+    newIntentListener: function(intent: string, handler: (context: Context) => void):Listener {
         return { unsubscribe: () => {} };
     },
     
-    contextListener: function(handler: (context: Context) => void):Listener {
+    newContextListener: function(handler: (context: Context) => void):Listener {
         return { unsubscribe: () => {} };
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "./build",
     "target": "es6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,10 @@
   dependencies:
     jsdom "^11.10.0"
 
+"@types/chai@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -45,6 +49,10 @@
 "@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+
+"@types/mocha@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.3.tgz#11f3a5629d67cd444fa6c94536576244e6a52ea9"
 
 "@types/node@*":
   version "10.1.4"
@@ -96,6 +104,10 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -103,6 +115,10 @@ asn1@~0.2.3:
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -145,6 +161,14 @@ browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
+buffer-from@^1.0.0, buffer-from@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -159,6 +183,21 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
+
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -177,6 +216,10 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -210,9 +253,21 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -221,6 +276,10 @@ deep-is@~0.1.3:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+diff@3.5.0, diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 domexception@^1.0.0:
   version "1.0.1"
@@ -233,6 +292,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+escape-string-regexp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 escodegen@^1.9.0:
   version "1.9.1"
@@ -305,13 +368,17 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.0.0:
+glob@7.1.2, glob@^7.0.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -325,6 +392,10 @@ glob@^7.0.0:
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
 handlebars@^4.0.6:
   version "4.0.11"
@@ -346,6 +417,14 @@ har-validator@~5.0.3:
   dependencies:
     ajv "^5.1.0"
     har-schema "^2.0.0"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 highlight.js@^9.0.0:
   version "9.12.0"
@@ -491,6 +570,10 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
 marked@^0.3.17:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
@@ -505,15 +588,49 @@ mime-types@^2.1.12, mime-types@~2.1.17:
   dependencies:
     mime-db "~1.33.0"
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+
+mkdirp@0.5.1, mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 nwsapi@^2.0.0:
   version "2.0.1"
@@ -558,6 +675,10 @@ path-is-absolute@^1.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -664,19 +785,26 @@ shelljs@^0.8.1:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@^0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 sshpk@^1.7.0:
   version "1.14.1"
@@ -696,6 +824,12 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -712,6 +846,19 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+ts-node@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.1.2.tgz#3221ca727a84bc66db1de8b647896621e38e8eaf"
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -727,6 +874,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedoc-default-themes@^0.5.0:
   version "0.5.0"
@@ -864,3 +1015,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"


### PR DESCRIPTION
After some very good API design discussions, two meetings centering around PR-13, I decided to take a crack at (hopefully) clarifying the existing API better and also providing some support for req/resp type interactions.

Major themes here are:
 - promises have defined return types now
 - method names changed to improve clarity (intent.send -> agent.raiseIntent)
 - added distinct resolveIntent and resolveContext methods
 - raiseIntent (FKA intent.send) now has a typed promise that includes a data payload of type any

In general, i went for explicit and verbose as opposed to fancy and/or overloaded - hence longer object names and explicit methods.

I also dropped context from signatures where we had both an Intent and a Context - this was confusing as the Intent itself has a context property.