### PR TITLE
removed type alias for IntentName and AppIdentifier

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,9 +33,7 @@ When making changes to the TypeScript interfaces, run `yarn test` to ensure ther
 ### Type aliases
 
 * [ActionMap](#actionmap)
-* [AppIdentifier](#appidentifier)
 * [Context](#context)
-* [IntentName](#intentname)
 
 ---
 
@@ -47,16 +45,7 @@ When making changes to the TypeScript interfaces, run `yarn test` to ensure ther
 
 **Ƭ ActionMap**: *[ActionMetadata](interfaces/actionmetadata.md)[]*
 
-*Defined in [interface.ts:18](/src/interface.ts#L18)*
-
-___
-<a id="appidentifier"></a>
-
-###  AppIdentifier
-
-**Ƭ AppIdentifier**: *`String`*
-
-*Defined in [interface.ts:3](/src/interface.ts#L3)*
+*Defined in [interface.ts:16](/src/interface.ts#L16)*
 
 ___
 <a id="context"></a>
@@ -66,15 +55,6 @@ ___
 **Ƭ Context**: *`Object`*
 
 *Defined in [interface.ts:1](/src/interface.ts#L1)*
-
-___
-<a id="intentname"></a>
-
-###  IntentName
-
-**Ƭ IntentName**: *`String`*
-
-*Defined in [interface.ts:2](/src/interface.ts#L2)*
 
 ___
 

--- a/docs/enums/openerror.md
+++ b/docs/enums/openerror.md
@@ -21,7 +21,7 @@
 
 **AppNotFound**:  = "AppNotFound"
 
-*Defined in [interface.ts:6](/src/interface.ts#L6)*
+*Defined in [interface.ts:4](/src/interface.ts#L4)*
 
 ___
 <a id="apptimeout"></a>
@@ -30,7 +30,7 @@ ___
 
 **AppTimeout**:  = "AppTimeout"
 
-*Defined in [interface.ts:8](/src/interface.ts#L8)*
+*Defined in [interface.ts:6](/src/interface.ts#L6)*
 
 ___
 <a id="erroronlaunch"></a>
@@ -39,7 +39,7 @@ ___
 
 **ErrorOnLaunch**:  = "ErrorOnLaunch"
 
-*Defined in [interface.ts:7](/src/interface.ts#L7)*
+*Defined in [interface.ts:5](/src/interface.ts#L5)*
 
 ___
 <a id="resolverunavailable"></a>
@@ -48,7 +48,7 @@ ___
 
 **ResolverUnavailable**:  = "ResolverUnavailable"
 
-*Defined in [interface.ts:9](/src/interface.ts#L9)*
+*Defined in [interface.ts:7](/src/interface.ts#L7)*
 
 ___
 

--- a/docs/enums/resolveerror.md
+++ b/docs/enums/resolveerror.md
@@ -20,7 +20,7 @@
 
 **NoAppsFound**:  = "NoAppsFound"
 
-*Defined in [interface.ts:13](/src/interface.ts#L13)*
+*Defined in [interface.ts:11](/src/interface.ts#L11)*
 
 ___
 <a id="resolvertimeout"></a>
@@ -29,7 +29,7 @@ ___
 
 **ResolverTimeout**:  = "ResolverTimeout"
 
-*Defined in [interface.ts:15](/src/interface.ts#L15)*
+*Defined in [interface.ts:13](/src/interface.ts#L13)*
 
 ___
 <a id="resolverunavailable"></a>
@@ -38,7 +38,7 @@ ___
 
 **ResolverUnavailable**:  = "ResolverUnavailable"
 
-*Defined in [interface.ts:14](/src/interface.ts#L14)*
+*Defined in [interface.ts:12](/src/interface.ts#L12)*
 
 ___
 

--- a/docs/interfaces/actionmetadata.md
+++ b/docs/interfaces/actionmetadata.md
@@ -25,7 +25,7 @@ Provides a mapping of Apps to Intents
 
 **● apps**: *[AppMetadata](appmetadata.md)[]*
 
-*Defined in [interface.ts:33](/src/interface.ts#L33)*
+*Defined in [interface.ts:31](/src/interface.ts#L31)*
 
 ___
 <a id="intent"></a>
@@ -34,7 +34,7 @@ ___
 
 **● intent**: *[IntentMetadata](intentmetadata.md)*
 
-*Defined in [interface.ts:32](/src/interface.ts#L32)*
+*Defined in [interface.ts:30](/src/interface.ts#L30)*
 
 ___
 

--- a/docs/interfaces/appmetadata.md
+++ b/docs/interfaces/appmetadata.md
@@ -22,9 +22,9 @@ App metadata is Desktop Agent specific - but should support a name property.
 
 ###  name
 
-**● name**: *[AppIdentifier](../#appidentifier)*
+**● name**: *`String`*
 
-*Defined in [interface.ts:41](/src/interface.ts#L41)*
+*Defined in [interface.ts:39](/src/interface.ts#L39)*
 
 ___
 

--- a/docs/interfaces/desktopagent.md
+++ b/docs/interfaces/desktopagent.md
@@ -31,7 +31,7 @@ A Desktop Agent can be connected to one or more App Directories and will use dir
 
 ▸ **broadcast**(context: *[Context](../#context)*): `void`
 
-*Defined in [interface.ts:100](/src/interface.ts#L100)*
+*Defined in [interface.ts:98](/src/interface.ts#L98)*
 
 Publishes context to other apps on the desktop.
 
@@ -50,7 +50,7 @@ ___
 
 ▸ **contextListener**(handler: *`function`*): [Listener](listener.md)
 
-*Defined in [interface.ts:115](/src/interface.ts#L115)*
+*Defined in [interface.ts:113](/src/interface.ts#L113)*
 
 Listens to incoming context broadcast from the Desktop Agent.
 
@@ -67,9 +67,9 @@ ___
 
 ###  intentListener
 
-▸ **intentListener**(intent: *[IntentName](../#intentname)*, handler: *`function`*): [Listener](listener.md)
+▸ **intentListener**(intent: *`String`*, handler: *`function`*): [Listener](listener.md)
 
-*Defined in [interface.ts:110](/src/interface.ts#L110)*
+*Defined in [interface.ts:108](/src/interface.ts#L108)*
 
 Listens to incoming Intents from the Agent.
 
@@ -77,7 +77,7 @@ Listens to incoming Intents from the Agent.
 
 | Param | Type |
 | ------ | ------ |
-| intent | [IntentName](../#intentname) |
+| intent | `String` |
 | handler | `function` |
 
 **Returns:** [Listener](listener.md)
@@ -89,7 +89,7 @@ ___
 
 ▸ **open**(name: *`String`*, context?: *[Context](../#context)*): `Promise`<`void`>
 
-*Defined in [interface.ts:85](/src/interface.ts#L85)*
+*Defined in [interface.ts:83](/src/interface.ts#L83)*
 
 Launches/links to an app by name.
 
@@ -111,9 +111,9 @@ ___
 
 ###  raiseIntent
 
-▸ **raiseIntent**(intent: *[IntentName](../#intentname)*, context: *[Context](../#context)*, target?: *`String`*): `Promise`<[IntentResolution](intentresolution.md)>
+▸ **raiseIntent**(intent: *`String`*, context: *[Context](../#context)*, target?: *`String`*): `Promise`<[IntentResolution](intentresolution.md)>
 
-*Defined in [interface.ts:105](/src/interface.ts#L105)*
+*Defined in [interface.ts:103](/src/interface.ts#L103)*
 
 Raises an intent to the desktop agent to resolve.
 
@@ -121,7 +121,7 @@ Raises an intent to the desktop agent to resolve.
 
 | Param | Type |
 | ------ | ------ |
-| intent | [IntentName](../#intentname) |
+| intent | `String` |
 | context | [Context](../#context) |
 | `Optional` target | `String` |
 
@@ -132,9 +132,9 @@ ___
 
 ###  resolve
 
-▸ **resolve**(intent: *[IntentName](../#intentname)*, context?: *[Context](../#context)*): `Promise`<`Array`<[ActionMetadata](actionmetadata.md)>>
+▸ **resolve**(intent: *`String`*, context?: *[Context](../#context)*): `Promise`<`Array`<[ActionMetadata](actionmetadata.md)>>
 
-*Defined in [interface.ts:95](/src/interface.ts#L95)*
+*Defined in [interface.ts:93](/src/interface.ts#L93)*
 
 Resolves an intent & context pair to a mapping of Intents and Apps (action metadata).
 
@@ -144,7 +144,7 @@ Resolve is effectively granting programmatic access to the Desktop Agent's resol
 
 | Param | Type |
 | ------ | ------ |
-| intent | [IntentName](../#intentname) |
+| intent | `String` |
 | `Optional` context | [Context](../#context) |
 
 **Returns:** `Promise`<`Array`<[ActionMetadata](actionmetadata.md)>>

--- a/docs/interfaces/intentmetadata.md
+++ b/docs/interfaces/intentmetadata.md
@@ -25,7 +25,7 @@ Intent descriptor
 
 **● displayName**: *`String`*
 
-*Defined in [interface.ts:25](/src/interface.ts#L25)*
+*Defined in [interface.ts:23](/src/interface.ts#L23)*
 
 ___
 <a id="name"></a>
@@ -34,7 +34,7 @@ ___
 
 **● name**: *`String`*
 
-*Defined in [interface.ts:24](/src/interface.ts#L24)*
+*Defined in [interface.ts:22](/src/interface.ts#L22)*
 
 ___
 

--- a/docs/interfaces/intentresolution.md
+++ b/docs/interfaces/intentresolution.md
@@ -34,7 +34,7 @@ var dataR = intentR.data;
 
 **● data**: *`Object`*
 
-*Defined in [interface.ts:56](/src/interface.ts#L56)*
+*Defined in [interface.ts:54](/src/interface.ts#L54)*
 
 ___
 <a id="source"></a>
@@ -43,7 +43,7 @@ ___
 
 **● source**: *`String`*
 
-*Defined in [interface.ts:55](/src/interface.ts#L55)*
+*Defined in [interface.ts:53](/src/interface.ts#L53)*
 
 ___
 <a id="version"></a>
@@ -52,7 +52,7 @@ ___
 
 **● version**: *`String`*
 
-*Defined in [interface.ts:57](/src/interface.ts#L57)*
+*Defined in [interface.ts:55](/src/interface.ts#L55)*
 
 ___
 

--- a/docs/interfaces/listener.md
+++ b/docs/interfaces/listener.md
@@ -22,7 +22,7 @@
 
 ▸ **unsubscribe**(): `any`
 
-*Defined in [interface.ts:64](/src/interface.ts#L64)*
+*Defined in [interface.ts:62](/src/interface.ts#L62)*
 
 Unsubscribe the listener object.
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,4 @@
 type Context = Object;
-type IntentName = String;
-type AppIdentifier = String;
 
 enum OpenError {
   AppNotFound = "AppNotFound",
@@ -38,7 +36,7 @@ interface ActionMetadata {
  * App metadata is Desktop Agent specific - but should support a name property.
  */
 interface AppMetadata {
-  name: AppIdentifier;
+  name: String;
 }
 
 /**
@@ -92,7 +90,7 @@ interface DesktopAgent {
    * If intent argument is falsey, then all possible intents - and apps corresponding to the intents - are resolved for the provided context.
    * If the resolution errors, it returns an `Error` with a string from the `ResolveError` enumeration.
    */
-  resolve(intent: IntentName, context?: Context): Promise<Array<ActionMetadata>>;
+  resolve(intent: String, context?: Context): Promise<Array<ActionMetadata>>;
 
   /**
    * Publishes context to other apps on the desktop.
@@ -102,12 +100,12 @@ interface DesktopAgent {
   /**
    * Raises an intent to the desktop agent to resolve.
    */
-  raiseIntent(intent: IntentName, context: Context, target?: String): Promise<IntentResolution>;
+  raiseIntent(intent: String, context: Context, target?: String): Promise<IntentResolution>;
 
   /**
    * Listens to incoming Intents from the Agent.
    */
-  intentListener(intent: IntentName, handler: (context: Context) => void): Listener;
+  intentListener(intent: String, handler: (context: Context) => void): Listener;
 
   /**
    * Listens to incoming context broadcast from the Desktop Agent.


### PR DESCRIPTION
as discussed in last WG.  These can be directly Strings.